### PR TITLE
Fix channels error

### DIFF
--- a/main.js
+++ b/main.js
@@ -43,7 +43,8 @@ function audioRecognize() {
                 "config": {
                     "encoding": "LINEAR16",
                     "sampleRateHertz": 44100, // 環境によってかわるっぽいので変えてください(おそらくエラーに正しい値が出てくると思います.
-                    "languageCode": "ja-JP"
+                    "languageCode": "ja-JP",
+                    "audio_channel_count": 2
                 },
                 "audio": {
                     "content": arrayBufferToBase64(result)


### PR DESCRIPTION
Fix channels error "InvalidArgument: 400 Must use single channel (mono) audio, but WAV header indicates 2 channels." returned by Google API.

OBS: remove your api key from the public repository!