### PR TITLE
Fix channels error and others

### DIFF
--- a/api_key.js
+++ b/api_key.js
@@ -1,1 +1,2 @@
 var apiKey = '';
+var languageCode = '';

--- a/api_key.js
+++ b/api_key.js
@@ -1,1 +1,1 @@
-var apiKey = 'AIzaSyDMHpLoru9PqrQxsb9yk6ulrDKWl8lJWA8';
+var apiKey = '';

--- a/main.js
+++ b/main.js
@@ -43,7 +43,8 @@ function audioRecognize() {
                 "config": {
                     "encoding": "LINEAR16",
                     "sampleRateHertz": 44100, // 環境によってかわるっぽいので変えてください(おそらくエラーに正しい値が出てくると思います.
-                    "languageCode": "ja-JP"
+                    "languageCode": languageCode,
+                    "audio_channel_count": 2
                 },
                 "audio": {
                     "content": arrayBufferToBase64(result)


### PR DESCRIPTION
Fix channels error "InvalidArgument: 400 Must use single channel (mono) audio, but WAV header indicates 2 channels." returned by Google API.
Clean api_key variable.
Support to configurable language cocde.